### PR TITLE
Add help tags for GTD spec

### DIFF
--- a/doc/gtd.norg
+++ b/doc/gtd.norg
@@ -279,6 +279,3 @@ This is not in an AOF
       - Opening a particular project view
       - Opening a particular context view (or next actions)
       - Doing a weekly review
-
-$comment
-vim:tw=100:ts=8:noet:ft=norg:norl:

--- a/doc/gtd.norg
+++ b/doc/gtd.norg
@@ -279,3 +279,6 @@ This is not in an AOF
       - Opening a particular project view
       - Opening a particular context view (or next actions)
       - Doing a weekly review
+
+$comment
+vim:tw=100:ts=8:noet:ft=norg:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -23,3 +23,15 @@ neorg-link-modifier	neorg.norg	/  *** The Link modifier
 neorg-continuation	neorg.norg	/  *** Object continuation
 neorg-insertions	neorg.norg	/  *** Insertions
 neorg-foreplay	neorg.norg	/  *** Foreplay
+neorg-gtd	gtd.norg	/* GTD in Neorg
+neorg-gtd-format	gtd.norg	/ ** Format
+neorg-gtd-format-tasks	gtd.norg	/  *** Task format
+neorg-gtd-organisation	gtd.norg	/  *** Top-level organization
+neorg-gtd-projects	gtd.norg	/  *** Projects management
+neorg-gtd-aof	gtd.norg	/  *** Area Of Focus
+neorg-gtd-structuree	gtd.norg	/ ** GTD structure for neorg
+neorg-gtd-capture	gtd.norg	/  *** Capture
+neorg-gtd-clarify	gtd.norg	/  *** Clarify
+neorg-gtd-organize	gtd.norg	/  *** Organize
+neorg-gtd-reflect	gtd.norg	/  *** Reflect
+neorg-gtd-engage	gtd.norg	/  *** Engage


### PR DESCRIPTION
Adds the `tags` specifications for the GTD help file.
It also ensures proper rendering by adding a vim modeline to the help page.